### PR TITLE
feat: confirmation prompt for destructive commands

### DIFF
--- a/pkg/cmd/operations.go
+++ b/pkg/cmd/operations.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"github.com/spf13/cobra"
 	keyring "github.com/zalando/go-keyring"
@@ -12,9 +13,12 @@ import (
 )
 
 const (
-	secretSavedMsg   = "secret saved"
+	secretCreatedMsg = "secret created"
+	secretUpdatedMsg = "secret updated"
 	secretDeletedMsg = "secret deleted"
 )
+
+var errAborted = errors.New("operation aborted")
 
 func newSetCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -35,9 +39,20 @@ func newSetCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			service, user := args[0], args[1]
 
-			secret, err := readSecret(cmd.InOrStdin())
+			secret, err := readSecret(cmd.InOrStdin(), cmd.OutOrStdout())
 			if err != nil {
 				return err
+			}
+
+			msg := secretCreatedMsg
+
+			_, err = keyring.Get(service, user)
+			if err == nil {
+				msg = secretUpdatedMsg
+
+				if err := confirm(cmd, "secret exists, overwrite?"); err != nil {
+					return err
+				}
 			}
 
 			err = keyring.Set(service, user, string(secret))
@@ -45,11 +60,13 @@ func newSetCommand() *cobra.Command {
 				return err
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), secretSavedMsg)
+			fmt.Fprintln(cmd.OutOrStdout(), msg)
 
 			return nil
 		},
 	}
+
+	cmd.Flags().Bool("yes", false, "automatically confirm secret overwrite prompts")
 
 	return cmd
 }
@@ -96,7 +113,14 @@ func newDeleteCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			service, user := args[0], args[1]
 
-			err := keyring.Delete(service, user)
+			_, err := keyring.Get(service, user)
+			if err == nil {
+				if err := confirm(cmd, "delete secret?"); err != nil {
+					return err
+				}
+			}
+
+			err = keyring.Delete(service, user)
 			if err != nil {
 				return err
 			}
@@ -107,6 +131,8 @@ func newDeleteCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().Bool("yes", false, "automatically confirm secret deletion prompts")
+
 	return cmd
 }
 
@@ -114,29 +140,57 @@ type fder interface {
 	Fd() uintptr
 }
 
-// writeSecret writes the secret to w. If w is a terminal, the secret will be
-// newline-terminated.
-func writeSecret(w io.Writer, secret string) (err error) {
-	f, ok := w.(fder)
+// writeSecret writes the secret to out. If out is a terminal, the secret will
+// be newline-terminated.
+func writeSecret(out io.Writer, secret string) (err error) {
+	f, ok := out.(fder)
 	if !ok || !term.IsTerminal(int(f.Fd())) {
-		_, err = w.Write([]byte(secret))
+		_, err = out.Write([]byte(secret))
 	} else {
-		_, err = fmt.Fprintln(w, secret)
+		_, err = fmt.Fprintln(out, secret)
 	}
 
 	return
 }
 
-// readSecret reads the secret from r. If r is a terminal, the user will be
-// prompted to enter it interactively.
-func readSecret(r io.Reader) ([]byte, error) {
-	f, ok := r.(fder)
-	if !ok || !term.IsTerminal(int(f.Fd())) {
-		return ioutil.ReadAll(r)
+// readSecret reads the secret from in. If in is a terminal, the user will be
+// prompted to enter it interactively. The prompt is written to out in this
+// case.
+func readSecret(in io.Reader, out io.Writer) ([]byte, error) {
+	fin, ok := in.(fder)
+	if !ok || !term.IsTerminal(int(fin.Fd())) {
+		return ioutil.ReadAll(in)
 	}
 
-	fmt.Fprint(os.Stdout, "Enter Secret: ")
-	defer fmt.Fprintln(os.Stdout)
+	fmt.Fprint(out, "enter secret: ")
+	defer fmt.Fprintln(out)
 
-	return term.ReadPassword(int(f.Fd()))
+	return term.ReadPassword(int(fin.Fd()))
+}
+
+// ask prints question to out and waits for confirmation input on in. Returns
+// errAborted if the user chose to stop or reading from in failed.
+func ask(in io.Reader, out io.Writer, question string) error {
+	fmt.Fprintf(out, "%s [y/N] ", question)
+	defer fmt.Fprintln(out)
+
+	r := bufio.NewReader(in)
+
+	c, _, _ := r.ReadRune()
+	switch c {
+	case 'y', 'Y':
+		return nil
+	default:
+		return errAborted
+	}
+}
+
+// confirm prompts the user to confirm the question unless the --yes flag is
+// set in cmd.
+func confirm(cmd *cobra.Command, question string) error {
+	if yes, err := cmd.Flags().GetBool("yes"); yes {
+		return err
+	}
+
+	return ask(cmd.InOrStdin(), cmd.OutOrStdout(), question)
 }

--- a/pkg/cmd/operations_test.go
+++ b/pkg/cmd/operations_test.go
@@ -44,7 +44,7 @@ func TestGetCommand_NotFound(t *testing.T) {
 	require.Error(cmd.Execute())
 }
 
-func TestSetCommand(t *testing.T) {
+func TestSetCommand_Create(t *testing.T) {
 	require := require.New(t)
 
 	keyring.MockInit()
@@ -60,14 +60,57 @@ func TestSetCommand(t *testing.T) {
 	cmd.SetOut(&buf)
 
 	require.NoError(cmd.Execute())
-	require.Equal(secretSavedMsg+"\n", buf.String())
+	require.Contains(buf.String(), secretCreatedMsg)
 
 	secret, err := keyring.Get(testService, testUser)
 	require.NoError(err)
 	require.Equal(testSecret, secret)
 }
 
-func TestDeleteCommand(t *testing.T) {
+func TestSetCommand_UpdateConfirm(t *testing.T) {
+	require := require.New(t)
+
+	keyring.MockInit()
+
+	require.NoError(keyring.Set(testService, testUser, testSecret))
+
+	var buf bytes.Buffer
+
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"set", testService, testUser, "--yes"})
+	cmd.SetIn(bytes.NewBuffer([]byte(testSecret + "new")))
+	cmd.SetOut(&buf)
+
+	require.NoError(cmd.Execute())
+	require.Contains(buf.String(), secretUpdatedMsg)
+
+	secret, err := keyring.Get(testService, testUser)
+	require.NoError(err)
+	require.Equal(testSecret+"new", secret)
+}
+
+func TestSetCommand_UpdateAbort(t *testing.T) {
+	require := require.New(t)
+
+	keyring.MockInit()
+
+	require.NoError(keyring.Set(testService, testUser, testSecret))
+
+	var buf bytes.Buffer
+
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"set", testService, testUser})
+	cmd.SetIn(bytes.NewBuffer([]byte(testSecret + "new")))
+	cmd.SetOut(&buf)
+
+	require.Error(cmd.Execute())
+
+	secret, err := keyring.Get(testService, testUser)
+	require.NoError(err)
+	require.Equal(testSecret, secret)
+}
+
+func TestDeleteCommand_Confirm(t *testing.T) {
 	require := require.New(t)
 
 	keyring.MockInit()
@@ -78,10 +121,51 @@ func TestDeleteCommand(t *testing.T) {
 
 	cmd := newRootCommand()
 	cmd.SetArgs([]string{"delete", testService, testUser})
+	cmd.SetIn(bytes.NewBuffer([]byte(`y`)))
 	cmd.SetOut(&buf)
 
 	require.NoError(cmd.Execute())
-	require.Equal(secretDeletedMsg+"\n", buf.String())
+	require.Contains(buf.String(), secretDeletedMsg)
+
+	_, err := keyring.Get(testService, testUser)
+	require.Error(err)
+}
+
+func TestDeleteCommand_Abort(t *testing.T) {
+	require := require.New(t)
+
+	keyring.MockInit()
+
+	require.NoError(keyring.Set(testService, testUser, testSecret))
+
+	var buf bytes.Buffer
+
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"delete", testService, testUser})
+	cmd.SetIn(bytes.NewBuffer(nil))
+	cmd.SetOut(&buf)
+
+	require.Error(cmd.Execute())
+
+	_, err := keyring.Get(testService, testUser)
+	require.NoError(err)
+}
+
+func TestDeleteCommand_AutoConfirm(t *testing.T) {
+	require := require.New(t)
+
+	keyring.MockInit()
+
+	require.NoError(keyring.Set(testService, testUser, testSecret))
+
+	var buf bytes.Buffer
+
+	cmd := newRootCommand()
+	cmd.SetArgs([]string{"delete", testService, testUser, "--yes"})
+	cmd.SetOut(&buf)
+
+	require.NoError(cmd.Execute())
+	require.Contains(buf.String(), secretDeletedMsg)
 
 	_, err := keyring.Get(testService, testUser)
 	require.Error(err)


### PR DESCRIPTION
This guards against accidental deletion and overwrite of existing secrets.

Users can auto-confirm the prompt by passing the `--yes` flag to the `set` and `delete` commands.